### PR TITLE
Fix localStorage errors in calendar and menu pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,12 @@
         if (window.firebase && firebase.database) {
             return firebase.database().ref(path).once('value').then(s => s.val());
         } else {
-            return Promise.resolve(JSON.parse(localStorage.getItem(path)) || null);
+            try {
+                return Promise.resolve(JSON.parse(localStorage.getItem(path)) || null);
+            } catch (e) {
+                console.warn('localStorage read failed', e);
+                return Promise.resolve(null);
+            }
         }
     }
 
@@ -191,7 +196,11 @@
         if (window.firebase && firebase.database) {
             return firebase.database().ref(path).set(data);
         } else {
-            localStorage.setItem(path, JSON.stringify(data));
+            try {
+                localStorage.setItem(path, JSON.stringify(data));
+            } catch (e) {
+                console.warn('localStorage write failed', e);
+            }
             return Promise.resolve();
         }
     }

--- a/menu.html
+++ b/menu.html
@@ -169,7 +169,12 @@
         if (window.firebase && firebase.database) {
             return firebase.database().ref(path).once('value').then(s => s.val());
         } else {
-            return Promise.resolve(JSON.parse(localStorage.getItem(path)) || null);
+            try {
+                return Promise.resolve(JSON.parse(localStorage.getItem(path)) || null);
+            } catch (e) {
+                console.warn('localStorage read failed', e);
+                return Promise.resolve(null);
+            }
         }
     }
 
@@ -177,7 +182,11 @@
         if (window.firebase && firebase.database) {
             return firebase.database().ref(path).set(data);
         } else {
-            localStorage.setItem(path, JSON.stringify(data));
+            try {
+                localStorage.setItem(path, JSON.stringify(data));
+            } catch (e) {
+                console.warn('localStorage write failed', e);
+            }
             return Promise.resolve();
         }
     }


### PR DESCRIPTION
## Summary
- fix localStorage usage on both pages so they don't crash when unavailable

## Testing
- `tidy -q -e index.html`
- `tidy -q -e menu.html`


------
https://chatgpt.com/codex/tasks/task_e_6886cb19b314832d9366ff8aef342028