### PR TITLE
Fix calendar month rollover

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,11 +295,15 @@
         }
 
         prevMonthBtn.addEventListener('click', () => {
+            // 月移動時に日付が31日のままだと月を飛び越えることがあるため1日に固定
+            currentDate.setDate(1);
             currentDate.setMonth(currentDate.getMonth() - 1);
             generateCalendar(currentDate);
         });
 
         nextMonthBtn.addEventListener('click', () => {
+            // 月移動時に日付が31日のままだと月を飛び越えることがあるため1日に固定
+            currentDate.setDate(1);
             currentDate.setMonth(currentDate.getMonth() + 1);
             generateCalendar(currentDate);
         });


### PR DESCRIPTION
## Summary
- prevent skipping months by resetting date before changing month in the calendar navigation

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68885dac3fa4832d9266016ea0f81c8a